### PR TITLE
Configure Web Auth using docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Chunkflow: make sure AWS_ACCESS_KEY_ID, etc... are set in environment variables!
 docker-compose -f docker/docker-compose.test.yml -p ci build
 docker-compose -f docker/docker-compose.test.yml -p ci run --rm sut ptw
 
+
+When deploying docker/docker-compose-CeleryExecutor.yml remember to deploy secrets!
+( or put in blank for no web auth )
+* echo '<Put some username here>' | docker secret add basic_auth_username -
+* echo '<Put some password here>' | docker secret add basic_auth_password -

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ docker-compose -f docker/docker-compose.test.yml -p ci run --rm sut ptw
 
 When deploying docker/docker-compose-CeleryExecutor.yml remember to deploy secrets!
 ( or put in blank for no web auth )
-* echo '<Put some username here>' | docker secret add basic_auth_username -
-* echo '<Put some password here>' | docker secret add basic_auth_password -
+* echo '<Put some username here>' | docker secret create basic_auth_username -
+* echo '<Put some password here>' | docker secret create basic_auth_password -

--- a/docker/docker-compose-CeleryExecutor.yml
+++ b/docker/docker-compose-CeleryExecutor.yml
@@ -133,7 +133,7 @@ services:
             - visualizer
         deploy:
             placement:
-                constraints: [ engine.labels.infrakit-role == worker ]
+                constraints: [ engine.labels.infrakit-role == manager ]
         environment:
             BASIC_AUTH_USERNAME_FILE: /run/secrets/basic_auth_username
             BASIC_AUTH_PASSWORD_FILE: /run/secrets/basic_auth_password

--- a/docker/docker-compose-CeleryExecutor.yml
+++ b/docker/docker-compose-CeleryExecutor.yml
@@ -138,7 +138,7 @@ services:
             - BASIC_AUTH_USERNAME
             - BASIC_AUTH_PASSWORD
         command: "bash -c 'apt-get update && apt-get install apache2-utils -y && \
-                  [ -n \"$$BASIC_AUTH_USERNAME\" ] \
+                  [ -n \"$$BASIC_AUTH_PASSWORD\" ] \
                          && AUTH_BASIC_STRING=\\\"AirflowAuthorization\\\" \
                          && htpasswd -b -c /etc/nginx/.htpasswd $${BASIC_AUTH_USERNAME} $${BASIC_AUTH_PASSWORD}
                          || AUTH_BASIC_STRING=off && \

--- a/docker/docker-compose-CeleryExecutor.yml
+++ b/docker/docker-compose-CeleryExecutor.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.3'
 services:
     redis:
         image: 'redis:3.2.7'
@@ -135,9 +135,11 @@ services:
             placement:
                 constraints: [ engine.labels.infrakit-role == worker ]
         environment:
-            - BASIC_AUTH_USERNAME
-            - BASIC_AUTH_PASSWORD
+            BASIC_AUTH_USERNAME_FILE: /run/secrets/basic_auth_username
+            BASIC_AUTH_PASSWORD_FILE: /run/secrets/basic_auth_password
         command: "bash -c 'apt-get update && apt-get install apache2-utils -y && \
+                  BASIC_AUTH_USERNAME=$$(</$$BASIC_AUTH_USERNAME_FILE) && \
+                  BASIC_AUTH_PASSWORD=$$(</$$BASIC_AUTH_PASSWORD_FILE) && \
                   [ -n \"$$BASIC_AUTH_PASSWORD\" ] \
                          && AUTH_BASIC_STRING=\\\"AirflowAuthorization\\\" \
                          && htpasswd -b -c /etc/nginx/.htpasswd $${BASIC_AUTH_USERNAME} $${BASIC_AUTH_PASSWORD}
@@ -171,3 +173,12 @@ services:
                       }\\n\
                   }\\n/\" \
                   /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf && nginx -g \"daemon off;\"'"
+        secrets:
+            - basic_auth_username
+            - basic_auth_password
+
+secrets:
+    basic_auth_username:
+        external: true
+    basic_auth_password:
+        external: true


### PR DESCRIPTION
In order to run CeleryExecutor that reverse proxies web portals using nginx, we must now create secrets ( as indicated in README)